### PR TITLE
Prevent gulp error for node-notifier

### DIFF
--- a/STARTER/package.json
+++ b/STARTER/package.json
@@ -11,5 +11,7 @@
     "normalize-scss": "^5.0.3",
     "spacelift": "^0.2.2"
   },
-  "dependencies": {}
+  "dependencies": {
+    "node-notifier": "^4.6.1"
+  }
 }


### PR DESCRIPTION
- Add node-notifier as a dependency in package.json to prevent error if not installed globally since it is required by the aluminum-capsule module